### PR TITLE
validation

### DIFF
--- a/distributions/common/templates/DanMarc2.json
+++ b/distributions/common/templates/DanMarc2.json
@@ -565,8 +565,8 @@
                     "rules":[{
                             "type":"SubfieldRules.checkLength",
                             "params":{
-                                "min":15,
-                                "max":15
+                                "min":12,
+                                "max":12
                             }
                         }
                     ]
@@ -3852,8 +3852,8 @@
                     "rules":[{
                         "type":"SubfieldRules.checkLength",
                         "params":{
-                            "min":15,
-                            "max":15
+                            "min":12,
+                            "max":12
                         }
                     }
                     ]

--- a/distributions/dataio/templates/dbc.json
+++ b/distributions/dataio/templates/dbc.json
@@ -878,8 +878,8 @@
                     "rules":[{
                         "type":"SubfieldRules.checkLength",
                         "params":{
-                            "min":15,
-                            "max":15
+                            "min":12,
+                            "max":12
                         }
                     }
                     ]

--- a/distributions/dataio/templates/dbcsingle.json
+++ b/distributions/dataio/templates/dbcsingle.json
@@ -1355,8 +1355,8 @@
                     "rules":[{
                         "type":"SubfieldRules.checkLength",
                         "params":{
-                            "min":15,
-                            "max":15
+                            "min":12,
+                            "max":12
                         }
                     }
                     ]

--- a/distributions/dataio/templates/ffu.json
+++ b/distributions/dataio/templates/ffu.json
@@ -799,6 +799,7 @@
             }
         },
         "795": "DanMarc2.fields.795",
+        "796": "DanMarc2.fields.796",
         "840": "DanMarc2.fields.840",
         "856": "DanMarc2.fields.856",
         "860": "DanMarc2.fields.860",

--- a/distributions/dataio/templates/ffubind.json
+++ b/distributions/dataio/templates/ffubind.json
@@ -736,6 +736,7 @@
             }
         },
         "795": "DanMarc2.fields.795",
+        "796": "DanMarc2.fields.796",
         "840": "DanMarc2.fields.840",
         "856": "DanMarc2.fields.856",
         "860": "DanMarc2.fields.860",

--- a/distributions/dataio/templates/metakompas.json
+++ b/distributions/dataio/templates/metakompas.json
@@ -32,7 +32,6 @@
 					"values": [ "870970" ]
                 },
                 "c": {
-                    "mandatory": true,
                     "repeatable": false,
                     "rules": [
                         {
@@ -44,7 +43,6 @@
                     ]
                 },
                 "d": {
-                    "mandatory": true,
                     "repeatable": false,
                     "rules": [
                         {
@@ -55,7 +53,10 @@
                         }
                     ]
                 },
-                "f": "DanMarc2.fields.001.subfields.f",
+                "f": {
+                    "repeatable": false,
+                    "values": [ "a" ]
+                },
                 "g": "DanMarc2.fields.001.subfields.g",
                 "o": "DanMarc2.fields.001.subfields.o",
                 "t": "DanMarc2.fields.001.subfields.t"

--- a/distributions/fbs/system-tests/update/common/ny-musik/request.marc
+++ b/distributions/fbs/system-tests/update/common/ny-musik/request.marc
@@ -40,6 +40,7 @@
 795 00 *å 19 *a Tandbørstehit *i tekst og melodi: Kalle B *i produktion, musik: Pelle Leth *e feat. Frederik Vedersø og Viggo Ny
 795 00 *å 20 *a Hva' vil du være? *i tekst og melodi: Kalle B *i produktion, musik: Mads Björn *e feat. Lydmor *i med Emil Falk
 795 00 *å 99 *y 0 *a Sommer
+796 00 *å 11 *a Symphony No. 3 in G Major, Hob.I:3: I. Allegro *z FR50X1767801 *l 5:01min *& spotify:track:6d4Kvuvov2SaWHALEZamFH
 900 00 *a Rasmussen *h Szhirley *z 700/1
 900 00 *a Shirley *z 700/1
 900 00 *a Haim *h Shirley *z 700/1

--- a/distributions/fbs/system-tests/update/common/ny-musik/result-new-common.marc
+++ b/distributions/fbs/system-tests/update/common/ny-musik/result-new-common.marc
@@ -40,6 +40,7 @@
 795 00 *å 19 *a Tandbørstehit *i tekst og melodi: Kalle B *i produktion, musik: Pelle Leth *e feat. Frederik Vedersø og Viggo Ny
 795 00 *å 20 *a Hva' vil du være? *i tekst og melodi: Kalle B *i produktion, musik: Mads Björn *e feat. Lydmor *i med Emil Falk
 795 00 *å 99 *y 0 *a Sommer
+796 00 *å 11 *a Symphony No. 3 in G Major, Hob.I:3: I. Allegro *z FR50X1767801 *l 5:01min *& spotify:track:6d4Kvuvov2SaWHALEZamFH
 900 00 *a Rasmussen *h Szhirley *z 700/1
 900 00 *a Shirley *z 700/1
 900 00 *a Haim *h Shirley *z 700/1

--- a/distributions/fbs/templates/fonogram.json
+++ b/distributions/fbs/templates/fonogram.json
@@ -682,8 +682,8 @@
                     "rules":[{
                         "type":"SubfieldRules.checkLength",
                         "params":{
-                            "min":15,
-                            "max":15
+                            "min":12,
+                            "max":12
                         }
                     }
                     ]


### PR DESCRIPTION
Validation for 796z (ISRC) changed to: max 12 and min 12 characters.
Template 'metakompas': 001cdf made un-mandatory