### PR TITLE
Remove forsrights environment variable from opencat-business

### DIFF
--- a/distributions/common/WireMocks/IDP/ok.json
+++ b/distributions/common/WireMocks/IDP/ok.json
@@ -1,0 +1,10 @@
+{
+  "authenticated": true,
+  "rights": [
+    {
+      "productName": "netpunkt.dk",
+      "name": "READ",
+      "description": ""
+    }
+  ]
+}

--- a/docker/compose/docker-compose.yml.tmpl
+++ b/docker/compose/docker-compose.yml.tmpl
@@ -89,7 +89,6 @@ services:
     image: docker-io.dbc.dk/opencat-business-service:devel
     environment:
       - INSTANCE_NAME=${USER}_dev
-      - FORSRIGHTS_URL=https://forsrights.addi.dk/2.0/
       - VIPCORE_ENDPOINT=${DEV_VIPCORE_ENDPOINT}
       - VIPCORE_CACHE_AGE=0
       - RAWREPO_RECORD_SERVICE_URL=${DEV_RAWREPO_RECORD_SERVICE_URL}

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -4,8 +4,6 @@ ENV JAVASCRIPT_BASEDIR /opt/payara5/deployments/opencat-business
 ENV JAVASCRIPT_POOL_SIZE 1
 
 ENV AUTH_PRODUCT_NAME netpunkt.dk
-ENV AUTH_USE_IP True
-ENV FORSRIGHTS_URL http://forsrights.addi.dk/1.2/
 
 ENV VIPCORE_ENDPOINT http://vipcore.iscrum-vip-extern-test.svc.cloud.dbc.dk
 ENV VIPCORE_CACHE_AGE 8

--- a/src/test/java/dk/dbc/opencat/service/AbstractOpencatBusinessContainerTest.java
+++ b/src/test/java/dk/dbc/opencat/service/AbstractOpencatBusinessContainerTest.java
@@ -46,7 +46,6 @@ public class AbstractOpencatBusinessContainerTest {
     private static final String HOLDINGS_ITEMS_DB_URL;
     private static final String RECORD_SERVICE_BASE_URL;
     private static final String VIPCORE_ENDPOINT = "http://vipcore.iscrum-vip-extern-test.svc.cloud.dbc.dk";
-    private static final String FORSRIGHTS_URL = "http://forsrights.addi.dk/2.0/";
     private static final String SOLR_URL = "http://solr:9090";
     private static final String OPENNUMBERROLL_URL = "http://opennumberroll:9090";
 
@@ -119,7 +118,6 @@ public class AbstractOpencatBusinessContainerTest {
                 .withEnv("RAWREPO_RECORD_SERVICE_URL", RECORD_SERVICE_BASE_URL)
                 .withEnv("VIPCORE_ENDPOINT", VIPCORE_ENDPOINT)
                 .withEnv("SOLR_URL", SOLR_URL)
-                .withEnv("FORSRIGHTS_URL", FORSRIGHTS_URL)
                 .withEnv("JAVA_MAX_HEAP_SIZE", "2G")
                 .withEnv("OPENNUMBERROLL_URL", OPENNUMBERROLL_URL)
                 .withEnv("OPENNUMBERROLL_NAME_FAUST_8", "faust")

--- a/start
+++ b/start
@@ -12,7 +12,6 @@ docker run --rm --name opencat-business-service -d -p ${opencat_business_service
     -e OPENNUMBERROLL_URL="https://opennumberroll.addi.dk/1.1/" \
     -e OPENNUMBERROLL_NAME_FAUST_8="faust" \
     -e OPENNUMBERROLL_NAME_FAUST="faust" \
-    -e FORSRIGHTS_URL="https://forsrights.addi.dk/2.0/" \
     -e DOUBLE_RECORD_MAIL_HOST="${DOUBLE_RECORD_MAIL_HOST}" \
     -e DOUBLE_RECORD_MAIL_PORT="${DOUBLE_RECORD_MAIL_PORT}" \
     -e DOUBLE_RECORD_MAIL_FROM="${DOUBLE_RECORD_MAIL_FROM}" \


### PR DESCRIPTION
It appears that opencat-business doesn't use forsrights, so might as well clean up a bit.