### PR TITLE
DA-1995 template bog.json allow 652 subfield &, fbs libraries must en…

### DIFF
--- a/distributions/fbs/templates/bog.json
+++ b/distributions/fbs/templates/bog.json
@@ -740,6 +740,9 @@
             "url": "http://www.kat-format.dk/danMARC2/Danmarc2.79.htm",
             "sorting":"&0\u00E5mnopqrzAaHhkEeFfCcTtBb1",
             "subfields":{
+                "&": {
+                    "repeatable": false
+                },
                 "m": "DanMarc2.fields.652.subfields.m",
                 "p": "DanMarc2.fields.652.subfields.p",
                 "i": "DanMarc2.fields.652.subfields.i",

--- a/distributions/fbs/templates/elektronisk.json
+++ b/distributions/fbs/templates/elektronisk.json
@@ -219,7 +219,44 @@
         "610": "bog.fields.610",
         "630": "bog.fields.630",
         "631": "bog.fields.631",
-        "652": "bog.fields.652",
+        "652":{
+            "url": "http://www.kat-format.dk/danMARC2/Danmarc2.79.htm",
+            "sorting":"&0\u00E5mnopqrzAaHhkEeFfCcTtBb1",
+            "subfields":{
+                "m": "DanMarc2.fields.652.subfields.m",
+                "p": "DanMarc2.fields.652.subfields.p",
+                "i": "DanMarc2.fields.652.subfields.i",
+                "v": "DanMarc2.fields.652.subfields.v",
+                "a": "DanMarc2.fields.652.subfields.a",
+                "h": "DanMarc2.fields.652.subfields.h",
+                "e": "DanMarc2.fields.652.subfields.e",
+                "f": "DanMarc2.fields.652.subfields.f",
+                "c": "DanMarc2.fields.652.subfields.c",
+                "t": "DanMarc2.fields.652.subfields.t",
+                "b": "DanMarc2.fields.652.subfields.b",
+                "z": "DanMarc2.fields.652.subfields.z",
+                "n": "DanMarc2.fields.652.subfields.n",
+                "o": "DanMarc2.fields.652.subfields.o",
+                "q": "DanMarc2.fields.652.subfields.q",
+                "r": "DanMarc2.fields.652.subfields.r"
+            },
+            "rules": [
+                {
+                    "type": "FieldRules.subfieldMandatoryIfSubfieldNotPresent",
+                    "params": {
+                        "subfield": "m",
+                        "not_presented_subfield": [ "652o", "654m", "654o" ]
+                    }
+                },
+                {
+                    "type": "FieldRules.subfieldMandatoryIfSubfieldNotPresent",
+                    "params": {
+                        "subfield": "o",
+                        "not_presented_subfield": [ "652m", "654m", "654o" ]
+                    }
+                }
+            ]
+        },
         "666": "bog.fields.666",
         "700": "bog.fields.700",
         "710": "bog.fields.710",

--- a/distributions/fbs/templates/film.json
+++ b/distributions/fbs/templates/film.json
@@ -233,7 +233,44 @@
         "610": "bog.fields.610",
         "630": "bog.fields.630",
         "631": "bog.fields.631",
-        "652": "bog.fields.652",
+        "652":{
+            "url": "http://www.kat-format.dk/danMARC2/Danmarc2.79.htm",
+            "sorting":"&0\u00E5mnopqrzAaHhkEeFfCcTtBb1",
+            "subfields":{
+                "m": "DanMarc2.fields.652.subfields.m",
+                "p": "DanMarc2.fields.652.subfields.p",
+                "i": "DanMarc2.fields.652.subfields.i",
+                "v": "DanMarc2.fields.652.subfields.v",
+                "a": "DanMarc2.fields.652.subfields.a",
+                "h": "DanMarc2.fields.652.subfields.h",
+                "e": "DanMarc2.fields.652.subfields.e",
+                "f": "DanMarc2.fields.652.subfields.f",
+                "c": "DanMarc2.fields.652.subfields.c",
+                "t": "DanMarc2.fields.652.subfields.t",
+                "b": "DanMarc2.fields.652.subfields.b",
+                "z": "DanMarc2.fields.652.subfields.z",
+                "n": "DanMarc2.fields.652.subfields.n",
+                "o": "DanMarc2.fields.652.subfields.o",
+                "q": "DanMarc2.fields.652.subfields.q",
+                "r": "DanMarc2.fields.652.subfields.r"
+            },
+            "rules": [
+                {
+                    "type": "FieldRules.subfieldMandatoryIfSubfieldNotPresent",
+                    "params": {
+                        "subfield": "m",
+                        "not_presented_subfield": [ "652o", "654m", "654o" ]
+                    }
+                },
+                {
+                    "type": "FieldRules.subfieldMandatoryIfSubfieldNotPresent",
+                    "params": {
+                        "subfield": "o",
+                        "not_presented_subfield": [ "652m", "654m", "654o" ]
+                    }
+                }
+            ]
+        },
         "666": "bog.fields.666",
         "700": "bog.fields.700",
         "710": "bog.fields.710",

--- a/distributions/fbs/templates/genstand.json
+++ b/distributions/fbs/templates/genstand.json
@@ -204,7 +204,44 @@
         "632": "DanMarc2.fields.632",
         "650": "DanMarc2.fields.650",
         "651": "DanMarc2.fields.651",
-        "652": "bog.fields.652",
+        "652":{
+            "url": "http://www.kat-format.dk/danMARC2/Danmarc2.79.htm",
+            "sorting":"&0\u00E5mnopqrzAaHhkEeFfCcTtBb1",
+            "subfields":{
+                "m": "DanMarc2.fields.652.subfields.m",
+                "p": "DanMarc2.fields.652.subfields.p",
+                "i": "DanMarc2.fields.652.subfields.i",
+                "v": "DanMarc2.fields.652.subfields.v",
+                "a": "DanMarc2.fields.652.subfields.a",
+                "h": "DanMarc2.fields.652.subfields.h",
+                "e": "DanMarc2.fields.652.subfields.e",
+                "f": "DanMarc2.fields.652.subfields.f",
+                "c": "DanMarc2.fields.652.subfields.c",
+                "t": "DanMarc2.fields.652.subfields.t",
+                "b": "DanMarc2.fields.652.subfields.b",
+                "z": "DanMarc2.fields.652.subfields.z",
+                "n": "DanMarc2.fields.652.subfields.n",
+                "o": "DanMarc2.fields.652.subfields.o",
+                "q": "DanMarc2.fields.652.subfields.q",
+                "r": "DanMarc2.fields.652.subfields.r"
+            },
+            "rules": [
+                {
+                    "type": "FieldRules.subfieldMandatoryIfSubfieldNotPresent",
+                    "params": {
+                        "subfield": "m",
+                        "not_presented_subfield": [ "652o", "654m", "654o" ]
+                    }
+                },
+                {
+                    "type": "FieldRules.subfieldMandatoryIfSubfieldNotPresent",
+                    "params": {
+                        "subfield": "o",
+                        "not_presented_subfield": [ "652m", "654m", "654o" ]
+                    }
+                }
+            ]
+        },
         "654": "DanMarc2.fields.654",
         "666": "bog.fields.666",
         "668":"DanMarc2.fields.668",

--- a/distributions/fbs/templates/periodicum.json
+++ b/distributions/fbs/templates/periodicum.json
@@ -291,7 +291,44 @@
         "631": "DanMarc2.fields.631",
         "650": "DanMarc2.fields.650",
         "651": "DanMarc2.fields.651",
-        "652": "bog.fields.652",
+        "652":{
+            "url": "http://www.kat-format.dk/danMARC2/Danmarc2.79.htm",
+            "sorting":"&0\u00E5mnopqrzAaHhkEeFfCcTtBb1",
+            "subfields":{
+                "m": "DanMarc2.fields.652.subfields.m",
+                "p": "DanMarc2.fields.652.subfields.p",
+                "i": "DanMarc2.fields.652.subfields.i",
+                "v": "DanMarc2.fields.652.subfields.v",
+                "a": "DanMarc2.fields.652.subfields.a",
+                "h": "DanMarc2.fields.652.subfields.h",
+                "e": "DanMarc2.fields.652.subfields.e",
+                "f": "DanMarc2.fields.652.subfields.f",
+                "c": "DanMarc2.fields.652.subfields.c",
+                "t": "DanMarc2.fields.652.subfields.t",
+                "b": "DanMarc2.fields.652.subfields.b",
+                "z": "DanMarc2.fields.652.subfields.z",
+                "n": "DanMarc2.fields.652.subfields.n",
+                "o": "DanMarc2.fields.652.subfields.o",
+                "q": "DanMarc2.fields.652.subfields.q",
+                "r": "DanMarc2.fields.652.subfields.r"
+            },
+            "rules": [
+                {
+                    "type": "FieldRules.subfieldMandatoryIfSubfieldNotPresent",
+                    "params": {
+                        "subfield": "m",
+                        "not_presented_subfield": [ "652o", "654m", "654o" ]
+                    }
+                },
+                {
+                    "type": "FieldRules.subfieldMandatoryIfSubfieldNotPresent",
+                    "params": {
+                        "subfield": "o",
+                        "not_presented_subfield": [ "652m", "654m", "654o" ]
+                    }
+                }
+            ]
+        },
         "654": "DanMarc2.fields.654",
         "665": "DanMarc2.fields.665",
         "666": "DanMarc2.fields.666",

--- a/distributions/fbs/templates/sammensat.json
+++ b/distributions/fbs/templates/sammensat.json
@@ -642,7 +642,44 @@
         "632": "DanMarc2.fields.632",
         "650": "DanMarc2.fields.650",
         "651": "DanMarc2.fields.651",
-        "652": "bog.fields.652",
+        "652":{
+            "url": "http://www.kat-format.dk/danMARC2/Danmarc2.79.htm",
+            "sorting":"&0\u00E5mnopqrzAaHhkEeFfCcTtBb1",
+            "subfields":{
+                "m": "DanMarc2.fields.652.subfields.m",
+                "p": "DanMarc2.fields.652.subfields.p",
+                "i": "DanMarc2.fields.652.subfields.i",
+                "v": "DanMarc2.fields.652.subfields.v",
+                "a": "DanMarc2.fields.652.subfields.a",
+                "h": "DanMarc2.fields.652.subfields.h",
+                "e": "DanMarc2.fields.652.subfields.e",
+                "f": "DanMarc2.fields.652.subfields.f",
+                "c": "DanMarc2.fields.652.subfields.c",
+                "t": "DanMarc2.fields.652.subfields.t",
+                "b": "DanMarc2.fields.652.subfields.b",
+                "z": "DanMarc2.fields.652.subfields.z",
+                "n": "DanMarc2.fields.652.subfields.n",
+                "o": "DanMarc2.fields.652.subfields.o",
+                "q": "DanMarc2.fields.652.subfields.q",
+                "r": "DanMarc2.fields.652.subfields.r"
+            },
+            "rules": [
+                {
+                    "type": "FieldRules.subfieldMandatoryIfSubfieldNotPresent",
+                    "params": {
+                        "subfield": "m",
+                        "not_presented_subfield": [ "652o", "654m", "654o" ]
+                    }
+                },
+                {
+                    "type": "FieldRules.subfieldMandatoryIfSubfieldNotPresent",
+                    "params": {
+                        "subfield": "o",
+                        "not_presented_subfield": [ "652m", "654m", "654o" ]
+                    }
+                }
+            ]
+        },
         "654": "DanMarc2.fields.654",
         "665": "DanMarc2.fields.665",
         "666": "bog.fields.666",


### PR DESCRIPTION
…rich books and ebooks records with classification in single and head records, templates pointing at bog.json have new field 652 without subfield &